### PR TITLE
fix(packaging): Declare missing runtime dependencies; single-source packaging metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,12 @@ dependencies = [
     "python-dateutil>=2.8.2",
     "tqdm>=4.65.0",
     "scikit-learn>=1.3.0",
+    "scipy>=1.10",
+    "statsmodels>=0.14.0",
 ]
+
+[project.optional-dependencies]
+storage = ["psycopg2-binary>=2.9"]
 
 [project.urls]
 Homepage = "https://github.com/andreaferrante/orderflow"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ tqdm~=4.65.0
 hmmlearn~=0.2.7
 scikit-learn~=1.3.0
 scipy~=1.10
+statsmodels~=0.14.0
 pytz>=2023.3
 psycopg2-binary>=2.9

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,4 @@
-from setuptools import setup, find_packages
+# Shim for legacy tooling: all package metadata lives in pyproject.toml.
+from setuptools import setup
 
-
-setup(
-    name="Orderflow",
-    version="0.6.0",
-    description="Orderflow trading data manager and data reshaper",
-    author="Andrea Ferrante",
-    author_email="nonicknamethankyou@gmail.com",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Build Tools",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3 :: Only",
-    ],
-    keywords="datetime, setuptools",
-    packages=find_packages(include=["orderflow*"]),
-    python_requires=">=3.6, <4",
-    install_requires=["pandas", "numpy", "polars", "matplotlib", "hmmlearn"],
-)
+setup()


### PR DESCRIPTION
This PR fixes three related packaging problems: a missing runtime dependency that breaks orderflow.stats on any clean install, two dependencies that exist in requirements.txt but not in the package metadata, and a setup.py that silently overrides pyproject.toml with stale values.

 1. statsmodels is used but declared nowhere

 orderflow/stats/hypothesis.py imports statsmodels in three functions — adf_test (line 118), kpss_test (line 175) and ljung_box_test (line 322). It is not listed in pyproject.toml, requirements.txt, or setup.py.

 Because the imports are lazy (inside the function bodies), the package installs and imports fine — the failure only surfaces when one of these functions is actually called:

 $ python -m venv venv && venv/bin/pip install .
 $ venv/bin/python -c "from orderflow.stats import adf_test; adf_test([...])"
 ModuleNotFoundError: No module named 'statsmodels'

 2. scipy and psycopg2-binary exist only in requirements.txt

 scipy is imported by orderflow/stats/hypothesis.py and orderflow/stats/correlation.py; psycopg2 by orderflow/storage/storage_service.py. Both are in requirements.txt, so a dev environment built from it works — but pip install orderflow (or installing the wheel) doesn't read requirements.txt and produces an environment where stats and storage are broken. Classic "works from requirements.txt, breaks from the package".

 scipy is added as a hard dependency. psycopg2-binary is added as an optional extra, since not every user needs the PostgreSQL layer:

 pip install "orderflow[storage]"

 3. setup.py silently overrode pyproject.toml with stale metadata

 setup.py and pyproject.toml both declared full package metadata, with different values. This isn't cosmetic — I built the wheel from the current main and inspected what actually ships:

 | Field           | setup.py        | pyproject.toml           | What the built wheel got       |
 |-----------------|-----------------|--------------------------|--------------------------------|
 | Requires-Python | >=3.6, <4       | >=3.9                    | >=3.6, <4 — setup.py won       |
 | Version         | static 0.6.0    | dynamic (setuptools_scm) | 0.6.0 — setup.py won, scm dead |
 | dependencies    | 5 packages      | 10 packages              | 10 — pyproject won             |
 | classifiers     | Python 3.7–3.11 | Python 3.9–3.14          | pyproject won                  |

 The two worst effects:
 - The wheel claims Python 3.6 compatibility. A user on 3.7/3.8 can pip install it without any warning and get runtime failures, because the code and the declared deps target 3.9+.
 - setuptools_scm was configured but effectively disabled — the static version="0.6.0" in setup.py always won, so the scm setup (dynamic = ["version"], write_to, commitizen tag_format) was dead configuration.

 The fix: setup.py is reduced to a compatibility shim (setup() with no arguments). Every value it carried either already exists in pyproject.toml (package discovery lives in [tool.setuptools.packages.find]) or was stale. With setuptools>=61 (already required by [build-system]), the shim isn't even strictly necessary — it's kept only for tools that still invoke python setup.py directly.

 ⚠️ Note on versioning (action needed)

 With the static version gone, setuptools_scm is now really in charge — and the repository currently has no git tags, so builds produce a dev version (0.4.1.dev359+g<hash> on my machine). To get proper releases, tag the current state:

 git tag v0.6.0 && git push --tags

 (matches the commitizen tag_format = "v$version" already configured in pyproject.toml). Alternatively, if you prefer static versioning, drop setuptools_scm instead — the point of this PR is that only one mechanism should exist.

 Changes

 - pyproject.toml: add scipy>=1.10, statsmodels>=0.14.0 to [project] dependencies; add [project.optional-dependencies] storage = ["psycopg2-binary>=2.9"]
 - setup.py: reduce to a no-argument shim
 - requirements.txt: add statsmodels~=0.14.0 to keep the dev environment in sync

 Verification

 Built the wheel before and after (pip wheel . --no-deps), diffed the METADATA: Requires-Python is now >=3.9, Requires-Dist includes scipy and statsmodels, Provides-Extra: storage present. Clean-venv install → from orderflow.stats import adf_test and import orderflow.storage.storage_service (with the extra) now resolve.