### PR TITLE
fix(backtester): repair signal_ptr desync and add LiveVWAPExit

### DIFF
--- a/orderflow/backtester/__init__.py
+++ b/orderflow/backtester/__init__.py
@@ -28,7 +28,7 @@ from orderflow.backtester.models import (
     TradeRecord,
     BacktestConfig,
 )
-from orderflow.backtester.execution import SlippageModel, FillSimulator
+from orderflow.backtester.execution import SlippageModel, SlippageMode, FillSimulator
 from orderflow.backtester.risk import RiskManager
 from orderflow.backtester.exits import (
     BaseExitStrategy,
@@ -40,7 +40,8 @@ from orderflow.backtester.exits import (
     CompositeExit,
     DynamicTPSLExit,
     CVDBreakEvenExit,
-    HourBasedExit
+    LiveVWAPExit,
+    HourBasedExit,
 )
 from orderflow.backtester.metrics import PerformanceMetrics, compute_metrics
 from orderflow.backtester.engine import BacktestEngine, BacktestResult
@@ -56,6 +57,7 @@ __all__ = [
     "BacktestConfig",
     # Execution
     "SlippageModel",
+    "SlippageMode",
     "FillSimulator",
     # Risk
     "RiskManager",
@@ -70,6 +72,7 @@ __all__ = [
     "HourBasedExit",
     "DynamicTPSLExit",
     "CVDBreakEvenExit",
+    "LiveVWAPExit",
     # Metrics
     "PerformanceMetrics",
     "compute_metrics",

--- a/orderflow/backtester/engine.py
+++ b/orderflow/backtester/engine.py
@@ -187,6 +187,10 @@ def _numba_core_loop(
                 signal_ptr += 1
             continue
 
+        # Consume signal slot for entry_mask hits while in position
+        if entry_mask[i] and signal_ptr < len(signal_sides):
+            signal_ptr += 1
+
         # --- In position: update extremes ---
         ticks_count += 1
         if side == 1:
@@ -571,6 +575,14 @@ class BacktestEngine:
         signal_ts    = np.ascontiguousarray(signals["Index"].values, dtype=np.int64)
         signal_sides = np.ascontiguousarray(signals["TradeType"].values, dtype=np.int64)
 
+        if len(signal_sides) > 0:
+            invalid = ~np.isin(signal_sides, [1, 2])
+            if invalid.any():
+                bad = np.unique(signal_sides[invalid]).tolist()
+                raise ValueError(
+                    f"TradeType contains invalid values: {bad}. Only 1 (SHORT) and 2 (LONG) are valid."
+                )
+
         # RTH filtering
         if self.trade_in_rth:
             signal_ts, signal_sides = self._filter_rth_signals(data, signal_ts, signal_sides)
@@ -807,6 +819,10 @@ class BacktestEngine:
                 continue
 
             # ---- In position: evaluate risk + strategy ----
+            # Consume signal slot for entry_mask hits while in position
+            if entry_mask[i] and signal_ptr < len(signal_sides):
+                signal_ptr += 1
+
             tick_obj = Tick(
                 index=i, timestamp=timestamps[i], datetime=datetimes[i],
                 price=price, bid=float(bids[i]), ask=float(asks[i]),
@@ -876,16 +892,6 @@ class BacktestEngine:
                     exit_strategy.on_exit(tick_obj, pos, exit_signal.reason)
 
                 pos.reset()
-
-                # Advance signal pointer past any signals during this trade
-                while signal_ptr < len(signal_sides):
-                    if signal_ptr >= len(signal_sides):
-                        break
-                    # Find next signal that is in the future
-                    # (signal_ts is implicit via entry_mask — we just step ptr)
-                    if entry_mask[i] and signal_ptr < len(signal_sides):
-                        signal_ptr += 1
-                    break
 
         # --- Close dangling position at end of data ---
         if not pos.is_flat:

--- a/orderflow/backtester/exits.py
+++ b/orderflow/backtester/exits.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+import pandas as pd
 
 from orderflow.backtester.models import (
     ExitReason,
@@ -605,6 +606,63 @@ class CVDBreakEvenExit(BaseExitStrategy):
                         "baseline_cvd": self._baseline_cvd,
                         "trigger_cvd": float(current_cvd),
                     },
+                )
+
+        return ExitSignal(should_exit=False)
+
+
+@dataclass
+class LiveVWAPExit(BaseExitStrategy):
+    """
+    Structural stop + live VWAP target exit.
+
+    Checks stop first (same-tick priority), then VWAP. Returns no exit_price
+    override — the engine fills at the current tick price.
+    """
+    signals_df: pd.DataFrame
+    vwap_col: str = "vwap"
+    _stop_lookup: Dict[int, float] = field(default_factory=dict, init=False, repr=False)
+    _current_stop: float = field(default=float("nan"), init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        for _, row in self.signals_df.iterrows():
+            self._stop_lookup[int(row["Index"])] = float(row["stop_loss"])
+
+    def on_entry(self, tick: Tick, position: PositionState) -> None:
+        self._current_stop = self._stop_lookup.get(int(tick.timestamp), float("nan"))
+
+    def on_tick(
+        self,
+        tick: Tick,
+        position: PositionState,
+        price_history: np.ndarray,
+        indicators: Dict[str, Any],
+    ) -> ExitSignal:
+        price = tick.price
+
+        if position.side == Side.LONG:
+            if price <= self._current_stop:
+                return ExitSignal(
+                    should_exit=True, reason=ExitReason.STOP_LOSS,
+                    metadata={"trigger": "structural_stop", "level": self._current_stop},
+                )
+            vwap = indicators.get(self.vwap_col)
+            if vwap is not None and not np.isnan(vwap) and price >= vwap:
+                return ExitSignal(
+                    should_exit=True, reason=ExitReason.CUSTOM,
+                    metadata={"trigger": "live_vwap", "level": float(vwap)},
+                )
+        elif position.side == Side.SHORT:
+            if price >= self._current_stop:
+                return ExitSignal(
+                    should_exit=True, reason=ExitReason.STOP_LOSS,
+                    metadata={"trigger": "structural_stop", "level": self._current_stop},
+                )
+            vwap = indicators.get(self.vwap_col)
+            if vwap is not None and not np.isnan(vwap) and price <= vwap:
+                return ExitSignal(
+                    should_exit=True, reason=ExitReason.CUSTOM,
+                    metadata={"trigger": "live_vwap", "level": float(vwap)},
                 )
 
         return ExitSignal(should_exit=False)


### PR DESCRIPTION
Fix signal_ptr never advancing when entry_mask fires during open position (both Numba and Python paths), causing later entries to read wrong signal direction. Add LiveVWAPExit strategy for structural stop + live VWAP target. Export SlippageMode and LiveVWAPExit from backtester __init__.